### PR TITLE
Email now accepts self-signed SSL and show errors

### DIFF
--- a/models/email.rb
+++ b/models/email.rb
@@ -1,6 +1,13 @@
 class Email
   include DataMapper::Resource
 
+
+  SMTP_ERRORS = [Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
+                 Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
+                 Errno::ECONNREFUSED, Net::SMTPSyntaxError, Net::SMTPFatalError]
+
+  SSL_ERRORS = [OpenSSL::SSL::SSLError]
+
   def self.default_repository_name #here we use the hosts_db for the Host objects
    :config_db
   end
@@ -26,14 +33,30 @@ class Email
         end
       end
       if cfg.method == :smtp
-        mail.delivery_method :smtp, address: cfg.host, port: cfg.port.to_i, user_name: cfg.user, password: cfg.password, authentication: 'plain', enable_starttls_auto: cfg.tls
-        mail.deliver!
+        mail.raise_delivery_errors = true
+        # setting open_ssl_verify_mode to true, makes mail to use the SSL, if it's valid or self-signed
+        # Maybe, in future we should verify it, but the info is a bit obscure: http://www.rubydoc.info/github/meskyanichi/backup/Backup/Notifier/Mail#openssl_verify_mode-instance_method
+        mail.delivery_method :smtp, address: cfg.host, port: cfg.port.to_i, user_name: cfg.user, password: cfg.password, authentication: 'plain', enable_starttls_auto: cfg.tls, return_response: true, openssl_verify_mode: "none"
+        response = mail.deliver!
+        
       elsif cfg.method == :sendmail
         mail.delivery_method :sendmail, :location => cfg.path
         mail.deliver!
       end
-    rescue
+    rescue *SMTP_ERRORS => e
+      NOTEX.synchronize do
+        notification = Notification.create(:type => :error, :sticky => true, :message => e.message)
+      end
       return false
+    rescue *SSL_ERRORS => e
+      NOTEX.synchronize do
+        notification = Notification.create(:type => :error, :sticky => true, :message => e.message)
+      end
+      return false;
+    rescue => e
+      NOTEX.synchronize do
+        notification = Notification.create(:type => :error, :sticky => true, :message => e.message)
+      end
     end
   end
 


### PR DESCRIPTION
Email now acepts self-signed SSL and show errors.
Also it will show it to us, if something failed by notification system.

Maybe it's not the greatest way to use the SMTP, but is far way better than failing and knowing NOTHING about what fails... :disappointed: 
