### PR TITLE
Don't limit the .widget-header's height that could cause the widget-head...

### DIFF
--- a/static/lib/css/style.css
+++ b/static/lib/css/style.css
@@ -374,7 +374,7 @@ body, html {
 
 	position: relative;
 
-	height: 40px;
+	min-height: 40px;
 	line-height: 40px;
 
 	background: #e8e8e8;


### PR DESCRIPTION
...er height to overlay other important links/menu elements (e.g. in the web editor's directory structure)