### PR TITLE
Add "ca-certificates" to install in monit

### DIFF
--- a/installer/monit/def
+++ b/installer/monit/def
@@ -16,7 +16,7 @@ endif
 if <%PKG_MANAGER%> == apt or <%PKG_MANAGER%> == dnf or <%PKG_MANAGER%> == yum or <%PKG_MANAGER%> == pacman or <%PKG_MANAGER%> == zypper
 
   # install monit:
-  install: wget tar gzip
+  install: wget tar gzip ca-certificates
   exec: mkdir -p /etc/monit/conf.d
   exec if <%ARCH%> == x86_64: wget http://github.com/AsydSolutions/monit/releases/download/release-5-13-asyd/monit-linux-x64 -O /tmp/monit
   exec if <%ARCH%> == i686: wget http://github.com/AsydSolutions/monit/releases/download/release-5-13-asyd/monit-linux-x86 -O /tmp/monit

--- a/installer/monit/def.sudo
+++ b/installer/monit/def.sudo
@@ -14,7 +14,7 @@ endif
 if <%PKG_MANAGER%> == apt or <%PKG_MANAGER%> == dnf or <%PKG_MANAGER%> == yum or <%PKG_MANAGER%> == pacman or <%PKG_MANAGER%> == zypper
 
   # install monit:
-  install: wget tar gzip
+  install: wget tar gzip ca-certificates
   exec: sudo mkdir -p /etc/monit/conf.d
   exec if <%ARCH%> == x86_64: wget http://github.com/AsydSolutions/monit/releases/download/release-5-13-asyd/monit-linux-x64 -O /tmp/monit
   exec if <%ARCH%> == i686: wget http://github.com/AsydSolutions/monit/releases/download/release-5-13-asyd/monit-linux-x86 -O /tmp/monit


### PR DESCRIPTION
To avoid these errors:
```
ERROR: The certificate of `github.com' is not trusted.
ERROR: The certificate of `github.com' hasn't got a known issuer.
```
We need to have a valid local SSL trusted store. This can be fixed by installing ca-certificates package which will download/install well-known trusted SSL certificates of CAs.