### PR TITLE
Allow HTTP Basic Authentication

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -37,6 +37,13 @@ class ASYD < Sinatra::Application
     if !File.directory? 'data'
       redirect '/setup'
     else
+      auth = Rack::Auth::Basic::Request.new(env)
+      if auth.provided? and auth.basic? and auth.credentials
+        u = User.auth(auth.credentials[0], auth.credentials[1])
+        if u
+          session[:username] = u.username
+        end
+      end
       if !session[:username] or User.first(:username => session[:username]).nil? then
         redirect '/login'
       else


### PR DESCRIPTION
To be used with compatible software like ```cURL```, ```Wget```, etc.: ```curl -v --basic -uUSERNAME:PASSWORD http://ASYDHOST:3000/SOMETHING```

The idea behind this is that we can easily create routes or views that export information from the database - e.g. JSON data - for use in another software or script. With the basic auth feature we can simplify this even more: Instead of using complicated cookie-based post-request logins we can just send the username and password in the URL or with separate parameters or options and we are not asked for a password anymore! In addition to this, we can use the cookie exported by ASYD for further use without having to re-authenticate.