### PR TITLE
Fix logic error in routes/user.rb causing ASYD to throw a stacktrace …

### DIFF
--- a/routes/user.rb
+++ b/routes/user.rb
@@ -1,6 +1,6 @@
 class ASYD < Sinatra::Application
   before /^(\/user|team)/ do
-    unless user.is_admin?
+    unless user and user.is_admin?
       redirect "/"
     end
   end


### PR DESCRIPTION
…and error if accessed by a not loggedin user

A possible error and stacktrace could look like this:

```
NoMethodError - undefined method `is_admin?' for nil:NilClass:
        /root/asyd/routes/user.rb:3:in `block in <class:ASYD>'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1603:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1603:in `block in compile!'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1006:in `[]'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1006:in `block in process_route'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1004:in `catch'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1004:in `process_route'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:957:in `block in filter!'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:957:in `each'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:957:in `filter!'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1075:in `block in dispatch!'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1058:in `block in invoke'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1058:in `catch'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1058:in `invoke'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1073:in `dispatch!'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:898:in `block in call!'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1058:in `block in invoke'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1058:in `catch'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1058:in `invoke'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:898:in `call!'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:886:in `call'
        /var/lib/gems/1.9.1/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in `call'
        /var/lib/gems/1.9.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /var/lib/gems/1.9.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /var/lib/gems/1.9.1/gems/rack-protection-1.5.3/lib/rack/protection/path_traversal.rb:16:in `call'
        /var/lib/gems/1.9.1/gems/rack-protection-1.5.3/lib/rack/protection/json_csrf.rb:18:in `call'
        /var/lib/gems/1.9.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /var/lib/gems/1.9.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /var/lib/gems/1.9.1/gems/rack-protection-1.5.3/lib/rack/protection/frame_options.rb:31:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/session/abstract/id.rb:225:in `context'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/session/abstract/id.rb:220:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/logger.rb:15:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:210:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/head.rb:13:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/methodoverride.rb:22:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/show_exceptions.rb:21:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:180:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:2014:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1478:in `block in call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1788:in `synchronize'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1478:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/tempfile_reaper.rb:15:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/lint.rb:49:in `_call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/lint.rb:37:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/showexceptions.rb:24:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/commonlogger.rb:33:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:217:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/chunked.rb:54:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/content_length.rb:15:in `call'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/lib/unicorn/http_server.rb:580:in `process_client'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/lib/unicorn/http_server.rb:674:in `worker_loop'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/lib/unicorn/http_server.rb:529:in `spawn_missing_workers'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/lib/unicorn/http_server.rb:140:in `start'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/bin/unicorn:126:in `<top (required)>'
        /usr/local/bin/unicorn:23:in `load'
        /usr/local/bin/unicorn:23:in `<main>'
NoMethodError: undefined method `join' for #<String:0x0000000320aa28>
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/show_exceptions.rb:37:in `rescue in call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/show_exceptions.rb:21:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:180:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:2014:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1478:in `block in call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1788:in `synchronize'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:1478:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/tempfile_reaper.rb:15:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/lint.rb:49:in `_call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/lint.rb:37:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/showexceptions.rb:24:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/commonlogger.rb:33:in `call'
        /var/lib/gems/1.9.1/gems/sinatra-1.4.5/lib/sinatra/base.rb:217:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/chunked.rb:54:in `call'
        /var/lib/gems/1.9.1/gems/rack-1.6.0/lib/rack/content_length.rb:15:in `call'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/lib/unicorn/http_server.rb:580:in `process_client'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/lib/unicorn/http_server.rb:674:in `worker_loop'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/lib/unicorn/http_server.rb:529:in `spawn_missing_workers'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/lib/unicorn/http_server.rb:140:in `start'
        /var/lib/gems/1.9.1/gems/unicorn-4.9.0/bin/unicorn:126:in `<top (required)>'
        /usr/local/bin/unicorn:23:in `load'
        /usr/local/bin/unicorn:23:in `<main>'
```

or in web browser:

![https://scr.meo.ws/files/2015-06-28-23-35-50-Screen%20Shot%202015-06-28%20at%2023.35.30.png](https://scr.meo.ws/files/2015-06-28-23-35-50-Screen%20Shot%202015-06-28%20at%2023.35.30.png)